### PR TITLE
Refine nfcore-atacseq

### DIFF
--- a/R/app-NfCoreAtacSeq.R
+++ b/R/app-NfCoreAtacSeq.R
@@ -60,7 +60,7 @@ EzAppNfCoreAtacSeq <- setRefClass(
 
 ##' @description get an nf-core/atacseq-formatted csv file
 getSampleSheet <- function(input, param){
-  if(any(input$meta$`Condition [Factor]` == "") || any(is.na(input$meta$`Condition [Factor]`)))
+  if(any(input$getColumn(param$grouping) == "") || any(is.na(input$getColumn(param$grouping))))
     stop("No conditions detected. Please add them in the dataset before calling NfCoreAtacSeqApp.")
   
   oDir <- '.' ## param[['resultDir']]


### PR DESCRIPTION
Hello @opitzl,

- `read_length` parameter has been replaced with `macs_gsize`, estimating the genome size internally via `getGenomeSize`. Since `read_length` is no longer needed, I'll update the corresponding ruby app shortly.
- a stop condition has been added to ensure that the column `Condition [Factor]` is checked before invoking the nfcore-atacseq app.

Cheers!