### PR TITLE
NfCoreStacSeq app: cleanup output directory

### DIFF
--- a/R/app-NfCoreAtacSeq.R
+++ b/R/app-NfCoreAtacSeq.R
@@ -149,8 +149,8 @@ getDdsFromConcensusPeaks <- function(output, param, grouping){
 
 cleanupOutFolder <- function(outFolder, dirsToRemove, keepBams=TRUE){
   if(!keepBams){
-    bamPath <- paste0(outFolder,"/bwa/merged_library/")
-    bamsToDelete <- dir(path=bamPath, pattern="*.bam*")
+    bamPath <- paste0(outFolder,"/bwa/")
+    bamsToDelete <- dir(path=bamPath, pattern="*.bam(.bai)?$", recursive=TRUE)
     file.remove(file.path(bamPath, bamsToDelete))
     cat("Deleted bam and bam.bai files form bwa directory.\n")
   }


### PR DESCRIPTION
A new function `cleanupOutFolder` has been added to the NfCoreAtacSeq app to apply the following changes to the output directory:

- remove subdirectories: `genome`, `trimgalore`, `fastqc`
- remove `bam` and `bam.bai` files from any subdirectories in `bwa`, if `keepBams` is set as False among params.