### PR TITLE
Make nfSampleInfo supporting comma-separated file paths

### DIFF
--- a/R/app-NfCoreAtacSeq.R
+++ b/R/app-NfCoreAtacSeq.R
@@ -98,14 +98,14 @@ getAtacSampleSheet <- function(input, param){
   #if(!dir.exists(oDir)) dir.create(path = oDir)
 
   csvPath <- file.path('dataset.csv')
+  listFastq <- input$getFullPathsList("Read1")
 
-  ## TODO: does not yet support comma-separated file paths
   nfSampleInfo <- ezFrame(
-    sample = input$getColumn(param$grouping),
-    fastq_1 = input$getFullPaths("Read1"),
-    fastq_2 = input$getFullPaths("Read2"),
-    replicate = ezReplicateNumber(input$getColumn(param$grouping)),
-    sid = input$getNames()
+    sample = rep(input$getColumn(param$grouping), lengths(listFastq)),
+    fastq_1 = unlist(listFastq),
+    fastq_2 = unlist(listFastq),
+    replicate = rep(ezReplicateNumber(input$getColumn(param$grouping)), lengths(listFastq)),
+    sid = rep(input$getNames(), lengths(listFastq))
   )
   write_csv(nfSampleInfo, csvPath)
   


### PR DESCRIPTION
The code splits comma-separated strings in a data.frame column into a separate rows.

The implementation uses base R that seems being faster than  other solutions, i.e. tidyr, when manipulating datasets with less than 200-500 rows (it has less overhead).

The function works in both cases: single and multiple fasta files.