### PR TITLE
Upgrade azimuth pan human to v1

### DIFF
--- a/R/app-ScSeurat.R
+++ b/R/app-ScSeurat.R
@@ -489,7 +489,7 @@ ezMethodScSeurat <- function(input = NA, output = NA, param = NA,
       }
       
       # Run CloudAzimuth - this handles everything automatically
-      scData <- CloudAzimuth(scData)
+      scData <- CloudAzimuth(scData, model_version = "v1")
       
       # Restore original seurat_clusters as default Idents (CloudAzimuth changes this)
       Idents(scData) <- scData$seurat_clusters


### PR DESCRIPTION
some of the differences are as follows:

   - v1 provides better quality control as it has a category called Unassigned meant for cells with low UMI counts.
    - The model is now calibrated, so the confidence measure provided is more robust. For example, a 0.8 confidence is meant to correspond to a real accuracy of 0.8 at the finest resolution (and better at lower resolution).
    - There are also pulmonary ionocytes in the data now (in addition to improvements to the data for certain other cell types).