### PR TITLE
fix(ezMail): keep jobs alive when post-run notification fails

### DIFF
--- a/R/messaging.R
+++ b/R/messaging.R
@@ -90,15 +90,26 @@ ezSessionInfo <- function() {
 ##' }
 ezMail = function(text = "done", subject = "r-mail", to = "") {
   stopifnot(to != "")
+  ## Recreate session tempdir if a node-level cleanup removed it mid-job;
+  ## system(..., input=) writes the input to tempdir() internally.
+  tempdir(check = TRUE)
   text = paste(
     c(text, paste("Host:", Sys.info()["nodename"]), paste("Dir:", getwd())),
     collapse = "\n"
   )
-  res = system(
-    paste("ssh fgcz-c-044 \" mail -s '", subject, "'", to, "\""),
-    input = text
+  res = tryCatch(
+    system(
+      paste("ssh fgcz-c-044 \" mail -s '", subject, "'", to, "\""),
+      input = text
+    ),
+    error = function(e) {
+      message("ezMail: notification failed (", conditionMessage(e), ")")
+      -1L
+    }
   )
-  stopifnot(res == 0)
+  if (res != 0) {
+    message("ezMail: non-zero exit (", res, "); continuing anyway")
+  }
 }
 
 ##' @title Is the email-address valid?


### PR DESCRIPTION
## Summary

- `ezMail()` currently halts R if `system(..., input=text)` can't write to `tempdir()`. That happens on our compute nodes when the session tempdir is removed underneath a long-running job (reproducible on fgcz-c-041 — `/tmp/Rtmp*` dirs got deleted mid-job for both a multi-hour Velocyto run and a 2-minute rmarkdown render in the same window).
- Because `appExitAction` runs `ezMail` *after* the actual work completes, the crash has no effect on the analysis — but in SUSHI wrappers it trips the post-R `g-req copy` step, leaving outputs stranded on `/scratch`.
- Fix: `tempdir(check = TRUE)` so R recreates its session tempdir if it was wiped, and wrap the notification in `tryCatch` + downgrade the exit-code check to a `message()`. A failed mail should never abort a finished job.

## Repro

```
INFO (ezRun) [...] EXECUTED CMD: rm -Rf  <sample>
Error in file(con, "w") : cannot open the connection
Calls: <Anonymous> ... <Anonymous> -> ezMail -> system -> writeLines -> file
  cannot open file '/tmp/Rtmpsqofi0/file8ca51c80cad9': No such file or directory
Execution halted
```

Both our VelocytoApp runs this week failed at this exact point after generating the loom file.

## Test plan

- [ ] Rerun VelocytoApp on a CellRangerMulti sample and confirm the SUSHI `g-req copy` step runs to completion even if the node clears `/tmp/Rtmp*` mid-run.
- [ ] Trigger `ezMail()` directly after `unlink(tempdir(), recursive = TRUE)` and confirm R logs a message and returns instead of halting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)