### PR TITLE
fix(scseurat): lazy-load optional annotation dependencies

### DIFF
--- a/R/app-ScSeurat.R
+++ b/R/app-ScSeurat.R
@@ -206,9 +206,7 @@ ezMethodScSeurat <- function(
   library(BiocParallel)
   library(scuttle)
   library(DropletUtils)
-  library(enrichR)
   library(decoupleR)
-  library(Azimuth)
 
   if (param$cores > 1) {
     BPPARAM <- MulticoreParam(workers = param$cores)
@@ -640,8 +638,8 @@ ezMethodScSeurat <- function(
       {
         futile.logger::flog.info("Starting Azimuth Pan-Human annotation...")
 
-        # Load AzimuthAPI package explicitly (CloudAzimuth is in AzimuthAPI, not Azimuth)
-        if (!require("AzimuthAPI", quietly = TRUE)) {
+        # CloudAzimuth is in AzimuthAPI, not Azimuth.
+        if (!requireNamespace("AzimuthAPI", quietly = TRUE)) {
           futile.logger::flog.error("AzimuthAPI package not available")
           stop("AzimuthAPI package required for CloudAzimuth function")
         }
@@ -658,7 +656,7 @@ ezMethodScSeurat <- function(
         }
 
         # Run CloudAzimuth - this handles everything automatically
-        scData <- CloudAzimuth(scData)
+        scData <- AzimuthAPI::CloudAzimuth(scData)
 
         # Restore original seurat_clusters as default Idents (CloudAzimuth changes this)
         Idents(scData) <- scData$seurat_clusters
@@ -1054,6 +1052,9 @@ querySignificantClusterAnnotationEnrichR <- function(
     )
     return(NULL)
   }
+  if (!requireNamespace("enrichR", quietly = TRUE)) {
+    stop("enrichR database requested, but package 'enrichR' is not available.")
+  }
 
   enrichRout <- list()
   columnsToKeep <- c(
@@ -1081,7 +1082,7 @@ querySignificantClusterAnnotationEnrichR <- function(
       next
     }
 
-    enriched <- enrichr(genes, dbs)
+    enriched <- enrichR::enrichr(genes, dbs)
 
     for (db in names(enriched)) {
       enriched_db <- enriched[[db]]

--- a/R/app-ScSeuratCombine.R
+++ b/R/app-ScSeuratCombine.R
@@ -97,9 +97,7 @@ ezMethodScSeuratCombine = function(
   library(SummarizedExperiment)
   library(SingleCellExperiment)
   library(AUCell)
-  library(enrichR)
   library(decoupleR)
-  library(Azimuth)
   library(BiocParallel)
   require(future)
 

--- a/R/app-ScSeuratCombinedLabelClusters.R
+++ b/R/app-ScSeuratCombinedLabelClusters.R
@@ -62,9 +62,7 @@ ezMethodScSeuratCombinedLabelClusters = function(
   library(SummarizedExperiment)
   library(SingleCellExperiment)
   library(AUCell)
-  library(enrichR)
   library(decoupleR)
-  library(Azimuth)
   library(qs2)
   library(BiocParallel)
 

--- a/R/app-ScSeuratFilterClusters.R
+++ b/R/app-ScSeuratFilterClusters.R
@@ -86,9 +86,7 @@ ezMethodScSeuratFilterClusters <- function(
   library(BiocParallel)
   library(scuttle)
   library(DropletUtils)
-  library(enrichR)
   library(decoupleR)
-  library(Azimuth)
   library(tidyverse)
 
   if (param$cores > 1) {

--- a/R/app-ScSeuratLabelClusters.R
+++ b/R/app-ScSeuratLabelClusters.R
@@ -66,9 +66,7 @@ ezMethodScSeuratLabelClusters <- function(
   library(BiocParallel)
   library(scuttle)
   library(DropletUtils)
-  library(enrichR)
   library(decoupleR)
-  library(Azimuth)
   library(tidyverse)
 
   if (param$cores > 1) {

--- a/R/app-SpatialSeurat.R
+++ b/R/app-SpatialSeurat.R
@@ -136,8 +136,6 @@ ezMethodSpatialSeurat <- function(
   on.exit(setwd(cwd), add = TRUE)
   library(Seurat)
   library(scater)
-  library(Azimuth)
-  library(enrichR)
   library(loupeR)
   library(future)
   library(BiocParallel)
@@ -475,6 +473,9 @@ getSpatialSeuratMarkersAndAnnotate <- function(scData, param, BPPARAM) {
 
   # run Azimuth
   if (ezIsSpecified(param$Azimuth) && param$Azimuth != "none") {
+    if (!requireNamespace("Azimuth", quietly = TRUE)) {
+      stop("Azimuth annotation requested, but package 'Azimuth' is not available.")
+    }
     environment(MyDietSeurat) <- asNamespace('Seurat')
     assignInNamespace("DietSeurat", MyDietSeurat, ns = "Seurat")
     rna_assay <- CreateAssay5Object(
@@ -482,7 +483,7 @@ getSpatialSeuratMarkersAndAnnotate <- function(scData, param, BPPARAM) {
     )
     scData[["RNA"]] <- scData[["Spatial"]] #rna_assay
     scData[["RNA"]] <- JoinLayers(scData[["RNA"]]) # Required for Azimuth compatibility with Seurat v5
-    scDataAzi <- RunAzimuth(scData, param$Azimuth, assay = "RNA") ## TODO support ADT
+    scDataAzi <- Azimuth::RunAzimuth(scData, param$Azimuth, assay = "RNA") ## TODO support ADT
 
     ##Rename annotation levels if neccessary:
     colnames(scDataAzi@meta.data) <- sub(

--- a/R/seuratUtils.R
+++ b/R/seuratUtils.R
@@ -808,10 +808,13 @@ getSeuratMarkersAndAnnotate <- function(scData, param, BPPARAM) {
 
   # run Azimuth
   if (ezIsSpecified(param$Azimuth) && param$Azimuth != "none") {
+    if (!requireNamespace("Azimuth", quietly = TRUE)) {
+      stop("Azimuth annotation requested, but package 'Azimuth' is not available.")
+    }
     environment(MyDietSeurat) <- asNamespace('Seurat')
     assignInNamespace("DietSeurat", MyDietSeurat, ns = "Seurat")
     scData[["RNA"]] <- JoinLayers(scData[["RNA"]]) # Required for Azimuth compatibility with Seurat v5
-    scDataAzi <- RunAzimuth(scData, param$Azimuth, assay = "RNA") ## TODO support ADT
+    scDataAzi <- Azimuth::RunAzimuth(scData, param$Azimuth, assay = "RNA") ## TODO support ADT
 
     ##Rename annotion levels if neccessary:
     colnames(scDataAzi@meta.data) <- sub(


### PR DESCRIPTION
Avoid loading Azimuth and enrichR unconditionally in ScSeurat-related workflows. These packages are only needed for optional annotation/enrichment steps, so disabled workflows should not fail because an optional dependency is unavailable or incompatible.

Load Azimuth only when Azimuth annotation is requested and call RunAzimuth via the Azimuth namespace. Load enrichR only when an Enrichr database is specified and call enrichr via the enrichR namespace. Also namespace CloudAzimuth through AzimuthAPI.