### PR TITLE
fix(seurat): pin BLAS/OpenMP to 1 thread before forking to avoid AUCell deadlock

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Depends:
     R (>= 4.5.0),stats,methods,utils,data.table,Biostrings,GenomicRanges,
     tidyverse,logger
 Imports:
+    RhpcBLASctl
 Suggests:
     testthat, knitr, gage, goseq, ChIPpeakAnno, DESeq2, TEQC,
     pathview, reshape2, vsn, Rsubread, preprocessCore, wesanderson,

--- a/R/app-ScSeurat.R
+++ b/R/app-ScSeurat.R
@@ -214,6 +214,10 @@ ezMethodScSeurat <- function(
     ## scDblFinder fails with many cells and MulticoreParam
     BPPARAM <- SerialParam()
   }
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
   require(future)
   plan("multicore", workers = param$cores)

--- a/R/app-ScSeuratCombine.R
+++ b/R/app-ScSeuratCombine.R
@@ -108,6 +108,10 @@ ezMethodScSeuratCombine = function(
   options(future.globals.maxSize = param$ram * 1024^3)
 
   BPPARAM <- MulticoreParam(workers = param$cores)
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
 
   cwd <- getwd()

--- a/R/app-ScSeuratCombinedLabelClusters.R
+++ b/R/app-ScSeuratCombinedLabelClusters.R
@@ -67,6 +67,10 @@ ezMethodScSeuratCombinedLabelClusters = function(
   library(BiocParallel)
 
   BPPARAM <- MulticoreParam(workers = param$cores)
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
 
   cwd <- getwd()

--- a/R/app-ScSeuratFilterClusters.R
+++ b/R/app-ScSeuratFilterClusters.R
@@ -95,6 +95,10 @@ ezMethodScSeuratFilterClusters <- function(
     ## scDblFinder fails with many cells and MulticoreParam
     BPPARAM <- SerialParam()
   }
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
   require(future)
   plan("multicore", workers = param$cores)

--- a/R/app-ScSeuratLabelClusters.R
+++ b/R/app-ScSeuratLabelClusters.R
@@ -75,6 +75,10 @@ ezMethodScSeuratLabelClusters <- function(
     ## scDblFinder fails with many cells and MulticoreParam
     BPPARAM <- SerialParam()
   }
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
   require(future)
   plan("multicore", workers = param$cores)

--- a/R/app-SeuratVisiumHD.R
+++ b/R/app-SeuratVisiumHD.R
@@ -161,6 +161,10 @@ ezMethodSeuratVisiumHD <- function(
   } else {
     BPPARAM <- SerialParam()
   }
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
   plan("multicore", workers = param$cores)
   set.seed(38)

--- a/R/app-SpatialSeurat.R
+++ b/R/app-SpatialSeurat.R
@@ -145,6 +145,10 @@ ezMethodSpatialSeurat <- function(
   } else {
     BPPARAM <- SerialParam()
   }
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
   plan("multicore", workers = param$cores)
   set.seed(38)

--- a/R/app-SpatialSeuratHD.R
+++ b/R/app-SpatialSeuratHD.R
@@ -155,6 +155,10 @@ ezMethodSpatialSeuratHD <- function(
   } else {
     BPPARAM <- SerialParam()
   }
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
   plan("multicore", workers = param$cores)
   set.seed(38)

--- a/R/app-VisiumHDSeurat.R
+++ b/R/app-VisiumHDSeurat.R
@@ -202,6 +202,10 @@ ezMethodVisiumHDSeurat <- function(
   } else {
     BPPARAM <- SerialParam()
   }
+  ## Pin BLAS/OpenMP to one thread before forking (MulticoreParam/future) to
+  ## avoid the fork-in-multithreaded-process deadlock (e.g. AUCell labeling).
+  RhpcBLASctl::blas_set_num_threads(1)
+  RhpcBLASctl::omp_set_num_threads(1)
   register(BPPARAM)
   plan("multicore", workers = param$cores)
   set.seed(38)


### PR DESCRIPTION
## Summary
- Fixes an intermittent fork-in-multithreaded-process deadlock in the Seurat/Spatial apps. `MulticoreParam` + `future::plan("multicore")` call `fork()` while threaded OpenBLAS holds an internal lock; the child inherits a locked mutex and hangs forever at ~0% CPU (observed at the AUCell cell-type-labeling step on `Dev/R/4.6.0`'s multithreaded `openblas-pthread`).
- Pins BLAS/OpenMP to a single thread via `RhpcBLASctl::blas_set_num_threads(1)` + `omp_set_num_threads(1)` immediately before the parallel setup (`register(BPPARAM)`), so forked children inherit single-threaded BLAS and there is no busy math thread to hold a lock at `fork()`.
- Identical 4-line block added to all 9 Seurat/Spatial apps; `RhpcBLASctl` added to `DESCRIPTION` as a hard `Imports` dependency.
### Apps touched
app-ScSeurat, app-ScSeuratCombine, app-ScSeuratFilterClusters, app-ScSeuratLabelClusters, app-ScSeuratCombinedLabelClusters, app-SpatialSeurat, app-SpatialSeuratHD, app-SeuratVisiumHD, app-VisiumHDSeurat.