### PR TITLE
fix(ezRun): RunHarmony harmony>=1.0 API + instance-aware project base URL

### DIFF
--- a/R/01classes.R
+++ b/R/01classes.R
@@ -448,7 +448,18 @@ EzApp <-
         "Returns URLs, that are tagged as Links, specified in the output list together with relevant metadata."
         use <- grepl("Link", output$tags)
         relUrls <- c(param$resultDir, unlist(output$meta[use])) ## always show the link to the resultdir and to all Links if available.
-        links <- paste(PROJECT_BASE_URL, relUrls, sep = "/")
+        ## Instance-aware project base URL: an explicit PROJECT_BASE_URL env var wins;
+        ## otherwise course-instance jobs (gstore under .../course_sushi/...) get the course
+        ## web host, and everything else falls back to the global PROJECT_BASE_URL (production).
+        baseUrl <- Sys.getenv("PROJECT_BASE_URL", unset = "")
+        if (!nzchar(baseUrl)) {
+          if (!is.null(param$dataRoot) && grepl("course_sushi", param$dataRoot)) {
+            baseUrl <- "https://fgcz-course1.bfabric.org/projects"
+          } else {
+            baseUrl <- PROJECT_BASE_URL
+          }
+        }
+        links <- paste(baseUrl, relUrls, sep = "/")
         links <- sub('.*\\/http:', 'http:', links) #Trim links for shinyApps
         return(links)
       },

--- a/R/seuratUtils.R
+++ b/R/seuratUtils.R
@@ -402,11 +402,12 @@ cellClustWithCorrection <- function(scDataList, param) {
       harmonyFactors <- "Condition"
     }
     # Calculate Harmony reduction
+    # harmony >= 1.0 renamed `reduction` -> `reduction.use` and removed `assay.use`
+    # (check_legacy_args() now hard-errors on assay.use); the assay is taken from the reduction.
     scData <- RunHarmony(
       scData,
       group.by.vars = harmonyFactors,
-      reduction = "pca",
-      assay.use = "SCT",
+      reduction.use = "pca",
       reduction.save = "harmony"
     )
 


### PR DESCRIPTION
## Two fixes surfaced while running ScSeuratCombine on the course SUSHI instance

### 1. Harmony integration crashes with harmony >= 1.0 (`assay.use is unhandled`)
`cellClustWithCorrection()` (seuratUtils.R) called:
```r
RunHarmony(scData, group.by.vars = harmonyFactors,
           reduction = "pca", assay.use = "SCT", reduction.save = "harmony")
```
harmony >= 1.0 renamed `reduction` -> `reduction.use` and **removed** `assay.use`; `check_legacy_args()` now hard-errors on it. With the installed **harmony 2.0.3**, every `ScSeuratCombine` run with `integrationMethod = Harmony` dies at:
```
Error in check_legacy_args(...) :
  Argument assay.use is unhandled. Please refer to the documentation for the valid harmony options!
```
Fix: drop `assay.use` and pass `reduction.use = "pca"` (the assay is inferred from the reduction). Verified against harmony 2.0.3 on `pbmc_small`: the new call produces a `harmony` reduction; the old call reproduces the error. RPCA/CCA paths are unaffected.

### 2. Completion-email links are wrong on non-production instances
`EzApp$outputLinks()` (01classes.R) always built links from the global `PROJECT_BASE_URL` (= `https://fgcz-gstore.uzh.ch/projects`, the production gstore host). On the **course** instance, jobs write to `/srv/GT/analysis/course_sushi/public/gstore/projects` (served at `https://fgcz-course1.bfabric.org/projects`), so the emailed links pointed at the production host, which does not serve course data -> dead links.

Fix: resolve the base URL instance-aware -
1. explicit `PROJECT_BASE_URL` env var wins (general override),
2. else course-instance jobs (gstore path under `.../course_sushi/...`) use the course web host,
3. else fall back to the global `PROJECT_BASE_URL`.

**Production behavior is unchanged**: with no env var and a non-course `dataRoot`, the global value is used exactly as before.

### Notes
- 2 files, minimal change; no version bump.
- Both issues confirmed live on the deployed `3.21.1`; the Harmony bug also affects production Harmony integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
