### PR TITLE
Compute OpticalDupRate as a fraction of all read pairs

### DIFF
--- a/R/app-DnaBamStats.R
+++ b/R/app-DnaBamStats.R
@@ -1111,9 +1111,9 @@ get_dna_picard_dup_stats <- function(
   )
 
   if (!is.na(result$optDuplicates) &&
-    !is.na(result$allDuplicates) &&
-    result$allDuplicates > 0) {
-    result$opticalDupRate <- 100 * result$optDuplicates / result$allDuplicates
+    !is.na(result$readPairs) &&
+    result$readPairs > 0) {
+    result$opticalDupRate <- 100 * result$optDuplicates / result$readPairs
   }
 
   result$notes <- paste(
@@ -1367,11 +1367,11 @@ parse_dna_bamstats_legacy_picard_metrics <- function(
   }
   opticalDupRate <- NA_real_
   if (!is.na(optDuplicates) &&
-    !is.na(allDuplicates) &&
-    allDuplicates > 0) {
+    !is.na(readPairs) &&
+    readPairs > 0) {
     opticalDupRate <- 100 *
       optDuplicates /
-      allDuplicates
+      readPairs
   }
   list(
     allDuplicates = allDuplicates,


### PR DESCRIPTION
`OpticalDupRate` in the DNABamStats report was computed as optical duplicate
pairs / **all duplicates**, which shows ~50–70% and misleads users into reading
it as "that share of all reads are duplicates" (a p29513 user hit exactly this).

This switches the denominator to `READ_PAIRS_EXAMINED` so it is the fraction of
**all read pairs** (~3–5%), which is what the `HighOpticalDuplicationRate > 20%`
red-flag threshold is intended for. Fixed in both `get_dna_picard_dup_stats` and
the legacy Picard parser.

Verified against the p29513 o42502 run's Picard metrics — e.g. `425021_13-Prep1`:
51.3% → 3.26%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
